### PR TITLE
Make the host ip explicit

### DIFF
--- a/src/vagrant-redis/Vagrantfile
+++ b/src/vagrant-redis/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # DOESN'T ALREADY EXIST ON THE USER'S SYSTEM.
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
-  config.vm.network "forwarded_port", guest: 6379, host: 6379, auto_correct: true
+  config.vm.network "forwarded_port", guest: 6379, host: 6379, auto_correct: true, host_ip: "127.0.0.1"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", "1024"]


### PR DESCRIPTION
Due to changes in Vagrant version 1.9.3 the host_ip has to be 127.0.0.1 instead of the default 0.0.0.0

See Ericbla's comment in this thread:

https://github.com/mitchellh/vagrant/issues/8395